### PR TITLE
Fix: Update image entries in sitemap to use URL type

### DIFF
--- a/app/server-sitemap.xml/route.ts
+++ b/app/server-sitemap.xml/route.ts
@@ -1,5 +1,5 @@
 import { getServerSideSitemap } from 'next-sitemap';
-import type { ISitemapField } from 'next-sitemap';
+import type { ISitemapField, IImageEntry } from 'next-sitemap';
 import { getAllStories } from '@/src/utils/stories';
 import { CATEGORIES } from '@/src/config/categories';
 import { getAllCountries } from '@/src/utils/countries';
@@ -30,14 +30,16 @@ export async function GET() {
     // Add image data if available
     images: story.imageUrl ? [
       {
-        loc: story.imageUrl.startsWith('http')
-          ? story.imageUrl
-          : `${baseUrl}${story.imageUrl.startsWith('/') ? story.imageUrl : `/${story.imageUrl}`}`,
+        loc: new URL(
+          story.imageUrl.startsWith('http')
+            ? story.imageUrl
+            : `${baseUrl}${story.imageUrl.startsWith('/') ? story.imageUrl : `/${story.imageUrl}`}`
+        ),
         title: story.title,
         caption: story.excerpt?.substring(0, 100) || story.title,
-        geo_location: story.country !== 'Global' ? story.country : undefined,
-        license: 'https://creativecommons.org/licenses/by/4.0/'
-      }
+        geoLocation: story.country !== 'Global' ? story.country : undefined,
+        license: new URL('https://creativecommons.org/licenses/by/4.0/')
+      } as IImageEntry
     ] : undefined,
   }));
 


### PR DESCRIPTION
## Description

This PR fixes the build failure by updating the image entries in the sitemap to use the correct types. The build was failing because the `loc` and `license` properties in the image entries should be of type `URL` rather than `string`.

## Changes

- Added import for `IImageEntry` type from `next-sitemap`
- Updated image entries to use `new URL()` for `loc` and `license` properties
- Fixed property name from `geo_location` to `geoLocation` to match the interface

## Testing

Once this PR is merged, the site should build successfully and the sitemap should be generated correctly.

## Root Cause

The build was failing with the following error:
```
Type error: Type '{ loc: string; lastmod: string; changefreq: "weekly"; priority: number; images: { loc: string; title: string; caption: string; geo_location: string; license: string; }[]; }[]' is not assignable to type 'ISitemapField[]'.
  Type '{ loc: string; lastmod: string; changefreq: "weekly"; priority: number; images: { loc: string; title: string; caption: string; geo_location: string; license: string; }[]; }' is not assignable to type 'ISitemapField'.
    Types of property 'images' are incompatible.
      Type '{ loc: string; title: string; caption: string; geo_location: string; license: string; }[]' is not assignable to type 'IImageEntry[]'.
        Type '{ loc: string; title: string; caption: string; geo_location: string; license: string; }' is not assignable to type 'IImageEntry'.
          Types of property 'loc' are incompatible.
            Type 'string' is not assignable to type 'URL'.
```

This was because the `loc` property in the `IImageEntry` interface should be of type `URL` rather than `string`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author