### PR TITLE
Fix: Remove reference to non-existent contentImages property in sitemap generation

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -103,25 +103,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         }
       ];
 
-      // Add additional images from the story content if available
-      // This helps search engines index more images from the story
-      if (enhancedStory.contentImages && enhancedStory.contentImages.length > 0) {
-        enhancedStory.contentImages.forEach(img => {
-          if (img.url && img.url !== fullImageUrl) {
-            const contentImageUrl = img.url.startsWith('http')
-              ? img.url
-              : `${baseUrl}${img.url.startsWith('/') ? img.url : `/${img.url}`}`;
-
-            sitemapEntry.images.push({
-              url: contentImageUrl,
-              title: img.alt || enhancedStory.title,
-              caption: img.caption || enhancedStory.excerpt?.substring(0, 100),
-              geo_location: enhancedStory.country !== 'Global' ? enhancedStory.country : undefined,
-              license: 'https://creativecommons.org/licenses/by/4.0/'
-            });
-          }
-        });
-      }
+      // Note: Content images extraction is disabled until we implement a proper content parser
+      // that can extract images from the story content
     }
 
     return sitemapEntry;


### PR DESCRIPTION
## Description

This PR fixes the build failure by removing the reference to a non-existent `contentImages` property in the sitemap generation. The build was failing because the `sitemap.ts` file was trying to access a `contentImages` property on the enhanced story object, but this property doesn't exist in the `Story` type definition.

## Changes

- Removed the code that was trying to access the `contentImages` property
- Added a comment explaining that content images extraction is disabled until we implement a proper content parser

## Testing

Once this PR is merged, the site should build successfully and the sitemap should be generated correctly.

## Root Cause

The build was failing with the following error:
```
Type error: Property 'contentImages' does not exist on type 'Story'.
```

This was because the `sitemap.ts` file was trying to access a `contentImages` property on the enhanced story object, but this property doesn't exist in the `Story` type definition.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author