### PR TITLE
Fix: Convert date to string in sitemap generator

### DIFF
--- a/src/utils/sitemap-generator.ts
+++ b/src/utils/sitemap-generator.ts
@@ -20,27 +20,27 @@ function generateSitemapXML(urls: SitemapURL[]): string {
   const xmlHeader = '<?xml version="1.0" encoding="UTF-8"?>';
   const sitemapStart = '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
   const sitemapEnd = '</urlset>';
-  
+
   const urlsXML = urls.map(({ url, lastmod, changefreq, priority }) => {
     let urlXML = `<url><loc>${url}</loc>`;
-    
+
     if (lastmod) {
       urlXML += `<lastmod>${lastmod}</lastmod>`;
     }
-    
+
     if (changefreq) {
       urlXML += `<changefreq>${changefreq}</changefreq>`;
     }
-    
+
     if (priority !== undefined) {
       urlXML += `<priority>${priority.toFixed(1)}</priority>`;
     }
-    
+
     urlXML += '</url>';
-    
+
     return urlXML;
   }).join('');
-  
+
   return `${xmlHeader}${sitemapStart}${urlsXML}${sitemapEnd}`;
 }
 
@@ -53,19 +53,19 @@ function generateSitemapIndexXML(sitemaps: { url: string; lastmod?: string }[]):
   const xmlHeader = '<?xml version="1.0" encoding="UTF-8"?>';
   const sitemapStart = '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
   const sitemapEnd = '</sitemapindex>';
-  
+
   const sitemapsXML = sitemaps.map(({ url, lastmod }) => {
     let sitemapXML = `<sitemap><loc>${url}</loc>`;
-    
+
     if (lastmod) {
       sitemapXML += `<lastmod>${lastmod}</lastmod>`;
     }
-    
+
     sitemapXML += '</sitemap>';
-    
+
     return sitemapXML;
   }).join('');
-  
+
   return `${xmlHeader}${sitemapStart}${sitemapsXML}${sitemapEnd}`;
 }
 
@@ -78,13 +78,13 @@ export async function generateSitemap(baseUrl: string, outputPath: string): Prom
   try {
     // Get all stories
     const stories = await getAllStories();
-    
+
     // Get all categories
     const categories = CATEGORIES;
-    
+
     // Get all countries
     const countries = getAllCountries();
-    
+
     // Static pages
     const staticPages: SitemapURL[] = [
       { url: `${baseUrl}/`, priority: 1.0, changefreq: 'daily' },
@@ -96,29 +96,39 @@ export async function generateSitemap(baseUrl: string, outputPath: string): Prom
       { url: `${baseUrl}/privacy-policy`, priority: 0.3, changefreq: 'yearly' },
       { url: `${baseUrl}/terms-of-service`, priority: 0.3, changefreq: 'yearly' },
     ];
-    
+
     // Story pages
-    const storyPages: SitemapURL[] = stories.map(story => ({
-      url: `${baseUrl}/stories/${story.slug}`,
-      lastmod: story.updatedAt || story.publishedAt,
-      priority: story.featured ? 0.9 : (story.editorsPick ? 0.8 : 0.7),
-      changefreq: 'monthly'
-    }));
-    
+    const storyPages: SitemapURL[] = stories.map(story => {
+      // Convert date to ISO string
+      const lastModDate = story.updatedAt || story.publishedAt;
+      const lastmod = typeof lastModDate === 'string'
+        ? lastModDate
+        : lastModDate instanceof Date
+          ? lastModDate.toISOString()
+          : new Date().toISOString();
+
+      return {
+        url: `${baseUrl}/stories/${story.slug}`,
+        lastmod,
+        priority: story.featured ? 0.9 : (story.editorsPick ? 0.8 : 0.7),
+        changefreq: 'monthly'
+      };
+    });
+
     // Category pages
     const categoryPages: SitemapURL[] = categories.map(category => ({
       url: `${baseUrl}/categories/${category.slug}`,
       priority: category.featured ? 0.8 : 0.7,
       changefreq: 'weekly'
     }));
-    
+
     // Country pages
     const countryPages: SitemapURL[] = countries.map(country => ({
       url: `${baseUrl}/countries/${country.toLowerCase().replace(/\s+/g, '-')}`,
       priority: 0.7,
       changefreq: 'weekly'
     }));
-    
+
     // Combine all URLs
     const allUrls = [
       ...staticPages,
@@ -126,13 +136,13 @@ export async function generateSitemap(baseUrl: string, outputPath: string): Prom
       ...categoryPages,
       ...countryPages
     ];
-    
+
     // Generate sitemap XML
     const sitemapXML = generateSitemapXML(allUrls);
-    
+
     // Write sitemap to file
     fs.writeFileSync(path.join(outputPath, 'sitemap.xml'), sitemapXML);
-    
+
     console.log(`Sitemap generated at ${path.join(outputPath, 'sitemap.xml')}`);
   } catch (error) {
     console.error('Error generating sitemap:', error);
@@ -147,7 +157,7 @@ export async function generateSitemap(baseUrl: string, outputPath: string): Prom
 export async function generateSitemapIndex(baseUrl: string, outputPath: string): Promise<void> {
   try {
     const today = new Date().toISOString().split('T')[0];
-    
+
     // Define sitemaps
     const sitemaps = [
       { url: `${baseUrl}/sitemap.xml`, lastmod: today },
@@ -155,13 +165,13 @@ export async function generateSitemapIndex(baseUrl: string, outputPath: string):
       { url: `${baseUrl}/sitemap-categories.xml`, lastmod: today },
       { url: `${baseUrl}/sitemap-countries.xml`, lastmod: today },
     ];
-    
+
     // Generate sitemap index XML
     const sitemapIndexXML = generateSitemapIndexXML(sitemaps);
-    
+
     // Write sitemap index to file
     fs.writeFileSync(path.join(outputPath, 'sitemap-index.xml'), sitemapIndexXML);
-    
+
     console.log(`Sitemap index generated at ${path.join(outputPath, 'sitemap-index.xml')}`);
   } catch (error) {
     console.error('Error generating sitemap index:', error);


### PR DESCRIPTION
## Description

This PR fixes the build failure by converting date objects to strings in the sitemap generator. The build was failing because the `lastmod` property in the `SitemapURL` interface should be of type `string`, but we were trying to assign a `string | Date` to it.

## Changes

- Updated the `storyPages` array in the sitemap generator to convert date objects to ISO strings
- Added proper type handling for different date formats

## Testing

Once this PR is merged, the site should build successfully and the sitemap should be generated correctly.

## Root Cause

The build was failing with the following error:
```
Type error: Type '{ url: string; lastmod: string | Date; priority: number; changefreq: "monthly"; }[]' is not assignable to type 'SitemapURL[]'.
  Type '{ url: string; lastmod: string | Date; priority: number; changefreq: "monthly"; }' is not assignable to type 'SitemapURL'.
    Types of property 'lastmod' are incompatible.
      Type 'string | Date' is not assignable to type 'string'.
        Type 'Date' is not assignable to type 'string'.
```

This was because the `SitemapURL` interface defines `lastmod` as an optional string, but in the `storyPages` array, we were trying to assign `story.updatedAt || story.publishedAt` which could be a `Date` object.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author