### PR TITLE
Fix: Update date validation to preserve future dates by default

### DIFF
--- a/src/utils/__tests__/date-utils.test.ts
+++ b/src/utils/__tests__/date-utils.test.ts
@@ -65,11 +65,21 @@ describe('Date Utilities', () => {
       expect(getSafeDateString(dateStr)).toBe(expected);
     });
 
-    it('should return current date for future dates', () => {
+    it('should preserve future dates by default', () => {
       const futureDate = new Date();
       futureDate.setFullYear(futureDate.getFullYear() + 1);
 
       const result = getSafeDateString(futureDate);
+
+      // The result should be the future date
+      expect(result).toBe(futureDate.toISOString());
+    });
+
+    it('should return current date for future dates when preserveFutureDates is false', () => {
+      const futureDate = new Date();
+      futureDate.setFullYear(futureDate.getFullYear() + 1);
+
+      const result = getSafeDateString(futureDate, false, false);
       const now = new Date();
 
       // The result should be close to now (within a few seconds)

--- a/src/utils/date-utils.ts
+++ b/src/utils/date-utils.ts
@@ -199,12 +199,12 @@ export function isArchived(publishDate: Date | string, archiveDays: number = 7):
 /**
  * Validate a date string and return a valid date
  * If the date is invalid, returns the current date
- * If the date is in the future, returns the current date by default, but can preserve future dates
+ * If the date is in the future, preserves the future date by default
  * @param dateStr - The date string to validate
- * @param preserveFutureDates - Whether to preserve future dates (default: false)
+ * @param preserveFutureDates - Whether to preserve future dates (default: true)
  * @returns A valid Date object
  */
-export function validateDate(dateStr: string | Date, preserveFutureDates: boolean = false): Date {
+export function validateDate(dateStr: string | Date, preserveFutureDates: boolean = true): Date {
   const now = new Date();
 
   // If it's already a Date object, check if it's valid
@@ -215,7 +215,8 @@ export function validateDate(dateStr: string | Date, preserveFutureDates: boolea
       return now;
     }
 
-    // Check if the date is in the future
+    // Always preserve future dates by default
+    // Only replace with current date if explicitly requested
     if (dateStr > now && !preserveFutureDates) {
       console.warn(`Future date detected: ${dateStr.toISOString()}, adjusting to current date`);
       return now;
@@ -234,7 +235,8 @@ export function validateDate(dateStr: string | Date, preserveFutureDates: boolea
       return now;
     }
 
-    // Check if the date is in the future
+    // Always preserve future dates by default
+    // Only replace with current date if explicitly requested
     if (date > now && !preserveFutureDates) {
       console.warn(`Future date detected: ${dateStr}, adjusting to current date`);
       return now;
@@ -251,16 +253,16 @@ export function validateDate(dateStr: string | Date, preserveFutureDates: boolea
 
 /**
  * Get a safe date string for database storage
- * Ensures the date is valid and optionally not in the future
+ * Ensures the date is valid and preserves future dates
  * @param dateStr - The date string to validate
  * @param silent - Whether to suppress console warnings (default: false)
- * @param preserveFutureDates - Whether to preserve future dates (default: false)
+ * @param preserveFutureDates - Whether to preserve future dates (default: true)
  * @returns A valid ISO date string
  */
 export function getSafeDateString(
   dateStr: string | Date | undefined,
   silent: boolean = false,
-  preserveFutureDates: boolean = false
+  preserveFutureDates: boolean = true
 ): string {
   try {
     // Handle undefined or null
@@ -279,7 +281,8 @@ export function getSafeDateString(
       return now.toISOString();
     }
 
-    // Check if the date is in the future
+    // Always preserve future dates by default
+    // Only replace with current date if explicitly requested
     if (dateObj > now && !preserveFutureDates) {
       if (!silent) console.warn(`Future date detected: ${dateStr}, adjusting to current date`);
       return now.toISOString();


### PR DESCRIPTION
## Description

This PR updates the date validation functions to preserve future dates by default, which should fix the issue where future dates are being replaced with the current date during build.

## Changes

1. Updated `getSafeDateString` to preserve future dates by default (changed default parameter from `false` to `true`)
2. Updated `validateDate` to preserve future dates by default (changed default parameter from `false` to `true`)
3. Updated tests to reflect these changes

## Testing

Once this PR is merged, the site should load correctly and display the original dates for stories, even if they are in the future.

## Root Cause

The issue was caused by the date validation functions replacing future dates with the current date by default. This was happening during the build process, causing all stories with future dates to show the current date instead.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author