### PR TITLE
Temporarily disable middleware to fix site error

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -3,7 +3,8 @@ import type { NextRequest } from 'next/server';
 import { errorMonitoringMiddleware } from './middleware/errorMonitoring';
 
 // Global flag to disable middleware in case of emergency
-const DISABLE_MIDDLEWARE = process.env.DISABLE_MIDDLEWARE === 'true';
+// Temporarily disable middleware to fix the site error
+const DISABLE_MIDDLEWARE = true; // process.env.DISABLE_MIDDLEWARE === 'true';
 
 // Safety timeout for middleware execution (5 seconds)
 const MIDDLEWARE_TIMEOUT = 5000;


### PR DESCRIPTION
## Description

This PR temporarily disables the middleware to fix the site error. The site is currently showing a 'Something went wrong!' error, which appears to be related to the middleware.

## Changes

1. Temporarily disabled middleware by setting DISABLE_MIDDLEWARE to true in middleware.ts

## Testing

Once this PR is merged, the site should load correctly.

## Root Cause

The site was showing a 'Something went wrong!' error, which appears to be related to the middleware. By temporarily disabling it, we can get the site back up while investigating the root cause.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author