### PR TITLE
Make header links clickable

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -26,7 +26,7 @@ export default function Header() {
 
   return (
     /* Updated header with blue gradient background and gold border */
-    <header className="sticky top-0 z-50 w-full transition-all duration-300 bg-gradient-to-r from-[#19273A] to-[#2A3F5F] text-white shadow-lg border-b-2 border-[#C9A14A]">
+    <header className="sticky top-0 z-[1000] isolate w-full transition-all duration-300 bg-gradient-to-r from-[#19273A] to-[#2A3F5F] text-white shadow-lg border-b-2 border-[#C9A14A]">
       {/* Top bar with contact info */}
       <div className="hidden lg:block py-0.5">
         <div className="container flex justify-between items-center text-xs">


### PR DESCRIPTION
Header click fix only. Keeps the original Header structure and navigation intact. Changes the header wrapper stacking class from z-50 to z-[1000] isolate so page layers cannot intercept header clicks. No other files changed.