### PR TITLE
Fix cookie banner click blocking

### DIFF
--- a/src/components/ui/CookieConsentBanner.tsx
+++ b/src/components/ui/CookieConsentBanner.tsx
@@ -87,8 +87,8 @@ export function CookieConsentBanner({ className = '' }: CookieConsentBannerProps
   if (!isVisible) return null;
 
   return (
-    <div className={`fixed bottom-0 left-0 right-0 z-50 bg-white border-t border-gray-200 shadow-lg ${className}`}>
-      <div className="max-w-7xl mx-auto px-4 py-4">
+    <div className={`fixed bottom-0 left-0 right-0 z-50 pointer-events-none ${className}`}>
+      <div className="max-w-7xl mx-auto px-4 py-4 bg-white border-t border-gray-200 shadow-lg pointer-events-auto">
         {!showDetails ? (
           // Simple consent banner
           <div className="flex flex-col sm:flex-row items-center justify-between gap-4">


### PR DESCRIPTION
Cookie banner pointer event fix only. Adds pointer-events-none to the fixed wrapper and pointer-events-auto to the visible banner content so the banner buttons still work while the wrapper cannot block page clicks. No other files changed.