### PR TITLE
Temporarily disable AI assistant mount

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,6 @@ import AffiliatePartners from '../src/components/affiliates/AffiliatePartners';
 import { cn } from '../src/utils/cn';
 import { AccessibilityProvider, SkipToContent } from '../src/components/accessibility/AccessibilityProvider';
 import { WebVitalsTracker } from '../src/components/analytics/WebVitalsTracker';
-import AITravelAssistantMount from '../src/components/experimental/AITravelAssistantMount';
 import { ClientLayoutWrapper } from './ClientLayoutWrapper';
 import { Suspense } from 'react';
 import { SearchParamsProvider } from '../src/components/ui/SearchParamsProvider';
@@ -195,7 +194,6 @@ export default function RootLayout({
               <Toaster />
             </SearchParamsProvider>
           </ErrorBoundary>
-          <AITravelAssistantMount />
           <Suspense fallback={null}>
             <WebVitalsTracker />
           </Suspense>


### PR DESCRIPTION
Test branch only. Temporarily removes the global AITravelAssistantMount render from app/layout.tsx to confirm whether it causes header click blocking after route and back navigation. No components deleted and no other files changed.