### PR TITLE
Keep homepage content below header click layer

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -56,7 +56,7 @@ export const metadata: Metadata = {
 
 export default function Home() {
   return (
-    <div className="min-h-screen">
+    <div className="min-h-screen relative z-0">
       {/* Hero Section with Featured Story */}
       <Hero />
 


### PR DESCRIPTION
Final fix branch. Adds relative z-0 to the homepage wrapper in app/page.tsx so homepage content stays below the sticky header click layer after returning Home. No Header, Hero, ClientLayoutWrapper, SWMount, AccessibilityProvider, CookieConsentBanner, monetisation, or navigation logic changes.