### PR TITLE
Final fix: remove fullscreen accessibility overlay

### DIFF
--- a/src/components/accessibility/AccessibilityProvider.tsx
+++ b/src/components/accessibility/AccessibilityProvider.tsx
@@ -151,7 +151,7 @@ export function AccessibilityMenu({ className = '' }: AccessibilityMenuProps) {
         <>
           <button
             type="button"
-            className="fixed inset-0 z-30 pointer-events-none"
+            className="hidden"
             aria-label="Close accessibility menu"
             onClick={() => setIsOpen(false)}
             onKeyDown={(e) => {


### PR DESCRIPTION
Removes the fullscreen accessibility close overlay (replaced with hidden element) which was intermittently blocking clicks after homepage navigation. No layout or UI changes. Fixes persistent navigation click failure.