### PR TITLE
[codex] Improve editorial hierarchy and story trust

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -210,7 +210,10 @@ export default function RootLayout({
                     {children}
                   </Suspense>
                 </main>
-                <AffiliatePartners />
+                <AffiliatePartners
+                  maxPartners={6}
+                  className="mt-12"
+                />
                 <Footer />
               </div>
               <Toaster />

--- a/app/stories/[slug]/page.tsx
+++ b/app/stories/[slug]/page.tsx
@@ -319,17 +319,20 @@ export default async function StoryPage({ params }: { params: Promise<StoryParam
               </p>
               {story.sourceUrl && (
                 <p className="mt-2">
-                  Source reference:{' '}
+                  Source:{' '}
                   <a
                     href={story.sourceUrl}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="font-medium text-[#8A6A20] underline"
                   >
-                    original source
+                    {story.source || 'Original reporting'}
                   </a>
                 </p>
               )}
+              <p className="mt-2 text-xs text-gray-600">
+                We distinguish original source material from our editorial context and update stories when material facts change.
+              </p>
             </div>
 
             <InterlineSponsorPlacement className="not-prose mb-8" />

--- a/src/components/recommendations/RelatedStories.tsx
+++ b/src/components/recommendations/RelatedStories.tsx
@@ -91,10 +91,10 @@ export function RelatedStories({ currentStory, limit = 4 }: RelatedStoriesProps)
       <div className="flex justify-between items-center mb-6">
         <h2 className="text-2xl font-bold">You Might Also Like</h2>
         <Link
-          href="/destinations"
+          href="/stories"
           className="text-sm text-blue-600 hover:text-blue-800 transition-colors flex items-center gap-1"
         >
-          View all destinations
+          View all stories
           <svg xmlns="https://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
             <path fillRule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clipRule="evenodd" />
           </svg>


### PR DESCRIPTION
## Change Type
- [x] Enhancement

## Description
- Limits the footer partner grid to six links after editorial content.
- Makes source attribution clearer on stories.
- Corrects the related-story discovery link.

## Impact Analysis
Improves editorial focus, reader trust, and content discovery without changing article data.

## Testing
- [x] TypeScript passed
- [x] Diff whitespace check passed

## Documentation
No documentation changes required.

## Deployment
Vercel preview deployment will validate the change.

## Quality Checklist
- [x] Scoped change
- [x] No secrets added

## Review Requirements
Standard review.

## Screenshots
Not applicable.

## Related Issues
None.

## Additional Notes
Brevo and Sentry activation remain intentionally deferred.