### PR TITLE
[codex] Fix live stories listing

### DIFF
--- a/app/stories/StoriesIndexClient.tsx
+++ b/app/stories/StoriesIndexClient.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
-import { StoryDatabase } from '@/src/services/storyDatabase';
 import { Story } from '@/types/Story';
 
 export default function StoriesIndexClient() {
@@ -15,9 +14,16 @@ export default function StoriesIndexClient() {
   useEffect(() => {
     const loadStories = async () => {
       try {
-        const storyDb = StoryDatabase.getInstance();
-        const allStories = await storyDb.getAllStories();
-        setStories(allStories);
+        const response = await fetch('/api/stories?limit=500', {
+          cache: 'no-store',
+        });
+
+        if (!response.ok) {
+          throw new Error(`Failed to load stories: ${response.status}`);
+        }
+
+        const payload = await response.json() as { stories?: Story[] };
+        setStories(Array.isArray(payload.stories) ? payload.stories : []);
       } catch (_error) {
         console.error(_error);
         setStories([]);


### PR DESCRIPTION
## What changed
- Load the public stories page from `/api/stories` instead of the browser-only mock store.

## Root cause
The publishing job writes stories to Supabase and the server API exposes them correctly, but the `/stories` client component cannot access server-side Supabase credentials and therefore rendered only bundled mock content.

## Validation
- `tsc --noEmit` passed.
- Confirmed the live API returns the June 23 published story.